### PR TITLE
Allowed settings to override hardcoded vars...

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -10,15 +10,17 @@ var SIMPLE_JOB = 1;
 var CRON_JOB  = 2;
 var jobCount = 0;
 
-var warnLimit = 500;
-
 var logger = require('log4js').getLogger(__filename);
 
 
 //For test
 var lateCount = 0;
 
-var Job = function(trigger, jobFunc, jobData){
+var Job = function(trigger, jobFunc, jobData, options){
+  this.settings = {
+      runLateJobs: options.runLateJobs || true,
+      lateJobInterval: options.lateJobInterval || 500
+  };
   this.data = (!!jobData)?jobData:null;
   this.func = jobFunc;
 
@@ -44,9 +46,17 @@ pro.run = function(){
     jobCount++;
     this.runTime++;
     var late = Date.now() - this.excuteTime();
-    if(late>warnLimit)
-      logger.warn('run Job count ' + jobCount + ' late :' + late + ' lateCount ' + (++lateCount));
-    this.func(this.data);
+    if (late>this.settings.lateJobInterval) {
+        logger.warn('Run Job: count ' + jobCount + ' late :' + late + ' lateCount ' + (++lateCount));
+
+        if (this.settings.runLateJobs) {
+            logger.warn("Skipping late job: count " + jobCount + ' late :' + late + ' lateCount ' + (++lateCount));
+        } else {
+            this.func(this.data);
+        }
+    } else {
+        this.func(this.data);
+    }
   }catch(e){
     logger.error("Job run error for exception ! " + e.stack);
   }
@@ -70,8 +80,8 @@ pro.excuteTime = function(){
  * @param jobDate The date the job use
  * @return The new instance of the give job or null if fail
  */
-function createJob(trigger, jobFunc, jobData){
-  return new Job(trigger, jobFunc, jobData);
+function createJob(trigger, jobFunc, jobData, options){
+  return new Job(trigger, jobFunc, jobData, options);
 }
 
 module.exports.createJob = createJob;

--- a/lib/job.js
+++ b/lib/job.js
@@ -47,10 +47,10 @@ pro.run = function(){
     this.runTime++;
     var late = Date.now() - this.excuteTime();
     if (late>this.settings.lateJobInterval) {
-        logger.warn('Run Job: count ' + jobCount + ' late :' + late + ' lateCount ' + (++lateCount));
+        //logger.warn('Run Job: count ' + jobCount + ' late :' + late + ' lateCount ' + (++lateCount));
 
         if (this.settings.runLateJobs) {
-            logger.warn("Skipping late job: count " + jobCount + ' late :' + late + ' lateCount ' + (++lateCount));
+            //logger.warn("Skipping late job: count " + jobCount + ' late :' + late + ' lateCount ' + (++lateCount));
         } else {
             this.func(this.data);
         }

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -20,8 +20,9 @@ var accuracy = 10;
 /**
  * Schedule a new Job
  */
-function scheduleJob(trigger, jobFunc, jobData){
-  var job = Job.createJob(trigger, jobFunc, jobData);
+function scheduleJob(trigger, jobFunc, jobData, options){
+  var settings = options || {};
+  var job = Job.createJob(trigger, jobFunc, jobData, settings);
   var excuteTime = job.excuteTime();
   var id = job.id;
 


### PR DESCRIPTION
Logical change to allow options to override two variables;
- Boolean to decide if late jobs are run
- The definition (interval) of a late job

Usage:

```
    var recurringJobId = pomelo.scheduleJob(rule, job, data, {
        runLateJobs: false,
        lateJobInterval: 5000
    });
```

Propose you merge this but don't document it as here may be more use cases for settings that I may find over the next few weeks as I integrate this module.

Great work, thankyou!!
