### PR TITLE
Update cronTrigger.js

### DIFF
--- a/lib/cronTrigger.js
+++ b/lib/cronTrigger.js
@@ -68,9 +68,9 @@ pro.nextExcuteTime = function(time){
         date.setSeconds(0);
         continue;
       }
-      date.setMonth(nextMonth);
-
+      
       date.setDate(1);
+      date.setMonth(nextMonth);
       date.setHours(0);
       date.setMinutes(0);
       date.setSeconds(0);
@@ -86,8 +86,8 @@ pro.nextExcuteTime = function(time){
 
         //If the date is in the next month, add month
         if(nextDom <= date.getDate() || nextDom > domLimit){
-          date.setMonth(date.getMonth() + 1);
           date.setDate(1);
+          date.setMonth(date.getMonth() + 1);
           date.setHours(0);
           date.setMinutes(0);
           date.setSeconds(0);


### PR DESCRIPTION
当下一个任务的执行时间跨月的时候,如果本月的最大天数大于下月的最大天数,Date.setMonth()会把月份改成下下个月,所以先执行Date.setDate(),再执行Date.setMonth(),可以保证跨月的时候不会跳月
