### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Cron trigger has 7 fiels, the format is very like the cronTab in linux, only add
 "0 30 10 1 4 *"      Fire at 10:30 on 1st of March  
 "15 15 15 10 10 *"   Fire at Octorber 10th, at 15:15:15.
 
-###Special charactors
+###Special characters
 Pomelo-schedule allow three kinds of spechial characters, they are '-', '/' and '.'.
 
 -: '-' means range. For example, 1-3 in the second field means the seconds 1, 2 and 3


### PR DESCRIPTION
@NetEase, I've corrected a typographical error in the documentation of the [pomelo-scheduler](https://github.com/NetEase/pomelo-scheduler) project. Specifically, I've changed charactor to character. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.